### PR TITLE
Added debian/eos-config-printer.install to actually install the files

### DIFF
--- a/debian/eos-config-printer.install
+++ b/debian/eos-config-printer.install
@@ -1,0 +1,7 @@
+etc/dbus-1/system.d
+usr/share/eos-config-printer
+usr/share/lib/systemd
+usr/share/dbus-1
+usr/share/polkit-1
+usr/lib/tmpfiles.d
+usr/bin


### PR DESCRIPTION
This was not needed when we only had a single package, but it is needed
now that we have the eos-config-printer-deps metapackage, otherwise only
the files under /usr/share/docs will be installed for eos-config-printer.

[endlessm/eos-shell#3971]
