### PR TITLE
Ensure any content present in the temporary folder gets removed on start

### DIFF
--- a/eos-config-printer.py
+++ b/eos-config-printer.py
@@ -144,10 +144,17 @@ class PrinterDriverOpenPrinting(PrinterDriver):
             self._installedPPDs.extend(ppd_files)
 
     def _ensureTemporaryDir(self):
-        if self._temporary_dir is not None and os.path.exists(self._temporary_dir):
-            return
-
-        os.makedirs(config.TEMPORARY_DIR, exist_ok=True)
+        if os.path.exists(config.TEMPORARY_DIR):
+            try:
+                # Make sure there are no leftovers from previous installation attempts.
+                dircontents = os.listdir(config.TEMPORARY_DIR)
+                for path in dircontents:
+                    abs_path = os.path.join(config.TEMPORARY_DIR, path)
+                    shutil.rmtree(abs_path, ignore_errors=True)
+            except OSError as e:
+                raise GLib.GError("Error listing contents of directory: %s" % repr(e))
+        else:
+            os.makedirs(config.TEMPORARY_DIR, exist_ok=True)
 
         try:
             self._temporary_dir = tempfile.mkdtemp(dir=config.TEMPORARY_DIR)


### PR DESCRIPTION
This way, should a previous installation failed in the middle of the
process (e.g. hard reboot), any leftovers in the temporary directory
will be wiped out on the next installation, leaving the folder empty at
the end of a succesfully finished process.

[endlessm/eos-shell#4939]