### PR TITLE
Fix wrong installation of systemd unit service file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,12 +33,16 @@ $(dbussystemservices_DATA): $(dbussystemservices_in_files)
 	@sed -e "s|\@bindir\@|$(bindir)|" $< > $@
 
 # systemd files for D-Bus activated service
-systemdservice_in_files = data/eos-config-printer.service.in
-systemdservice_DATA = $(systemdservice_in_files:.service.in=.service)
-systemdservicedir = $(datadir)/$(systemdsystemunitdir)
+systemdunit_in_files = data/eos-config-printer.service.in
+systemdunit_DATA = $(systemdunit_in_files:.service.in=.service)
 
-$(systemdservice_DATA): $(systemdservice_in_files) $(systemdsystemunitdir)
+$(systemdunit_DATA): $(systemdunit_in_files) $(systemdsystemunitdir)
 	@sed -e "s|\@bindir\@|$(bindir)|" $< > $@
+
+# Set systemd unit directory that follows $prefix too for distcheck.
+AM_DISTCHECK_CONFIGURE_FLAGS = \
+	--with-systemdunitdir='$${libdir}/systemd/system' \
+	$(NULL)
 
 # systemd tmpfiles.d
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
@@ -63,7 +67,7 @@ EXTRA_DIST = \
 	$(dbusinterfaces_DATA) \
 	$(dbussystemservices_in_files) \
 	$(polkit_rules_in_files) \
-	$(systemdservice_in_files) \
+	$(systemdunit_in_files) \
 	$(tmpfiles_DATA) \
 	autogen.sh \
 	config.py.in \
@@ -73,7 +77,7 @@ EXTRA_DIST = \
 
 CLEANFILES = \
 	$(dbussystemservices_DATA) \
-	$(systemdservice_DATA) \
+	$(systemdunit_DATA) \
 	$(polkit_rules_DATA) \
 	config.py \
 	$(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,17 @@ PRINTERS_ADMIN_GROUP=lpadmin
 AC_SUBST(PRINTERS_ADMIN_GROUP)
 
 # For systemd
-AC_SUBST([systemdsystemunitdir], [$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+PKG_CHECK_EXISTS([systemd], [],
+	[AC_MSG_ERROR([systemd required to build $PACKAGE_NAME])])
+
+AC_ARG_WITH([systemdunitdir],
+	[AS_HELP_STRING([--with-systemdunitdir],
+			[systemd unit file directory])],
+	[systemdunitdir=$withval],
+	[systemdunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd`])
+AS_IF([test "x$systemdunitdir" = x],
+	[AC_MSG_ERROR([no path for systemd unit directory])])
+AC_SUBST([systemdunitdir])
 
 AC_CONFIG_FILES([
 Makefile

--- a/data/com.endlessm.Config.Printing.service.in
+++ b/data/com.endlessm.Config.Printing.service.in
@@ -2,3 +2,4 @@
 Name=com.endlessm.Config.Printing
 Exec=@bindir@/eos-config-printer
 User=root
+SystemdService=eos-config-printer.service

--- a/debian/eos-config-printer.install
+++ b/debian/eos-config-printer.install
@@ -1,6 +1,6 @@
 etc/dbus-1/system.d
+lib/systemd
 usr/share/eos-config-printer
-usr/share/lib/systemd
 usr/share/dbus-1
 usr/share/polkit-1
 usr/lib/tmpfiles.d


### PR DESCRIPTION
This makes possible for systemd to manage the
com.endlessm.Config.Printing D-Bus service.

[endlessm/eos-shell#5084]