### PR TITLE
Use the right directory /var/lib/eos-config-printer/ppd everywhere

### DIFF
--- a/data/eos-config-printer.conf
+++ b/data/eos-config-printer.conf
@@ -1,5 +1,5 @@
 # Type Path    Mode UID  GID  Age Argument
-d /var/lib/cups/ppd/eos-config-printer 0755 root root -
-Z /var/lib/cups/ppd/eos-config-printer 0755 root root -
 d /var/lib/eos-config-printer 0755 root root -
 Z /var/lib/eos-config-printer 0755 root root -
+d /var/lib/eos-config-printer/ppd 0755 root root -
+Z /var/lib/eos-config-printer/ppd 0755 root root -

--- a/eos-config-printer.py
+++ b/eos-config-printer.py
@@ -130,7 +130,7 @@ class PrinterDriverOpenPrinting(PrinterDriver):
 
         # Move the driver into the desired location, search for the directory
         # containing the PPD files and create symlinks pointing there from the
-        # /var/cups/ppd/openprinting directory, so that CUPS can find them.
+        # /var/lib/eos-config-printer/ppd  directory, so that CUPS can find them.
         # Also, fill the self._installedPPDs list to report to the caller.
         moved_dirs = self._deployDriverDirectories(extraction_dir)
         self._installedPPDs = []


### PR DESCRIPTION
Initially this was going to be /var/lib/cups/ppd/eos-config-printer, but
I changed it before the first release and forgot to update one comment
and the systemd's tmpfiles.d snippet that gets installed with the debian
package, resulting in an empty (and useless) directory being created.